### PR TITLE
feat(koya): add Koya limit variants (KS/L±1, KS/L±2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.1.0] - 2026-08-30
+
+### Added
+
+- `@echecs/koya/limit-m1` — Koya with limit 50% − ½ (FIDE C.07 9.2 + 14.5)
+- `@echecs/koya/limit-m2` — Koya with limit 50% − 1 (FIDE C.07 9.2 + 14.5)
+- `@echecs/koya/limit-p1` — Koya with limit 50% + ½ (FIDE C.07 9.2 + 14.5)
+- `@echecs/koya/limit-p2` — Koya with limit 50% + 1 (FIDE C.07 9.2 + 14.5)
+
 ## [3.0.3] - 2026-04-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,46 @@ koya(player: string, games: Game[][]): number
 
 `tiebreak` is an alias for `koya` for use in tiebreak pipelines.
 
+### `/limit-m1`
+
+**FIDE C.07 sections 9.2 + 14.5.** Koya with the threshold lowered to 50% − ½:
+opponents qualify when they scored strictly more than half the rounds minus one
+half point.
+
+```typescript
+import { koyaLimitM1, tiebreak } from '@echecs/koya/limit-m1';
+```
+
+### `/limit-m2`
+
+**FIDE C.07 sections 9.2 + 14.5.** Koya with the threshold lowered to 50% − 1:
+opponents qualify when they scored strictly more than half the rounds minus one
+point.
+
+```typescript
+import { koyaLimitM2, tiebreak } from '@echecs/koya/limit-m2';
+```
+
+### `/limit-p1`
+
+**FIDE C.07 sections 9.2 + 14.5.** Koya with the threshold raised to 50% + ½:
+opponents qualify when they scored strictly more than half the rounds plus one
+half point.
+
+```typescript
+import { koyaLimitP1, tiebreak } from '@echecs/koya/limit-p1';
+```
+
+### `/limit-p2`
+
+**FIDE C.07 sections 9.2 + 14.5.** Koya with the threshold raised to 50% + 1:
+opponents qualify when they scored strictly more than half the rounds plus one
+point.
+
+```typescript
+import { koyaLimitP2, tiebreak } from '@echecs/koya/limit-p2';
+```
+
 ### Exports
 
 ```typescript
@@ -62,6 +102,9 @@ export { koya, tiebreak } from '@echecs/koya';
 // Types
 export type { Game, GameKind, Player, Result } from '@echecs/koya';
 ```
+
+Each limit variant subpath exports its named function (e.g. `koyaLimitP1`), a
+`tiebreak` alias, and the same `Game`, `GameKind`, `Player`, and `Result` types.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,14 @@
     "./limit-m2": {
       "import": "./dist/limit-m2.js",
       "types": "./dist/limit-m2.d.ts"
+    },
+    "./limit-p1": {
+      "import": "./dist/limit-p1.js",
+      "types": "./dist/limit-p1.d.ts"
+    },
+    "./limit-p2": {
+      "import": "./dist/limit-p2.js",
+      "types": "./dist/limit-p2.d.ts"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./limit-m1": {
+      "import": "./dist/limit-m1.js",
+      "types": "./dist/limit-m1.d.ts"
+    },
+    "./limit-m2": {
+      "import": "./dist/limit-m2.js",
+      "types": "./dist/limit-m2.d.ts"
     }
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2018,13 +2018,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@oxc-project/types@0.133.0': {}
 
   '@oxc-project/types@0.140.0': {}

--- a/src/__tests__/limits-up.spec.ts
+++ b/src/__tests__/limits-up.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { koyaLimitP1 } from '../limit-p1.js';
+import { koyaLimitP2 } from '../limit-p2.js';
+
+import type { CompletedRound, Player } from '@echecs/tournament';
+
+const PLAYERS: Player[] = [
+  { id: 'A', points: 2.5, rank: 1 },
+  { id: 'B', points: 2, rank: 2 },
+  { id: 'C', points: 1, rank: 3 },
+  { id: 'D', points: 0.5, rank: 4 },
+];
+
+const ROUNDS: CompletedRound[] = [
+  {
+    byes: [],
+    games: [
+      { black: 'B', result: 'white', white: 'A' },
+      { black: 'D', result: 'white', white: 'C' },
+    ],
+  },
+  {
+    byes: [],
+    games: [
+      { black: 'C', result: 'white', white: 'A' },
+      { black: 'D', result: 'white', white: 'B' },
+    ],
+  },
+  {
+    byes: [],
+    games: [
+      { black: 'D', result: 'draw', white: 'A' },
+      { black: 'C', result: 'white', white: 'B' },
+    ],
+  },
+];
+
+describe('koya raised limits', () => {
+  it('KS/L+1 raises the limit by half a point', () => {
+    expect(koyaLimitP1('A', ROUNDS, PLAYERS)).toBe(1);
+  });
+
+  it('KS/L+2 raises the limit by one point', () => {
+    expect(koyaLimitP2('A', ROUNDS, PLAYERS)).toBe(0);
+  });
+});

--- a/src/__tests__/limits.spec.ts
+++ b/src/__tests__/limits.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { koya } from '../index.js';
+import { koyaLimitM1 } from '../limit-m1.js';
+import { koyaLimitM2 } from '../limit-m2.js';
+
+import type { CompletedRound, Player } from '@echecs/tournament';
+
+const PLAYERS: Player[] = [
+  { id: 'A', points: 2.5, rank: 1 },
+  { id: 'B', points: 2, rank: 2 },
+  { id: 'C', points: 1, rank: 3 },
+  { id: 'D', points: 0.5, rank: 4 },
+];
+
+const ROUNDS: CompletedRound[] = [
+  {
+    byes: [],
+    games: [
+      { black: 'B', result: 'white', white: 'A' },
+      { black: 'D', result: 'white', white: 'C' },
+    ],
+  },
+  {
+    byes: [],
+    games: [
+      { black: 'C', result: 'white', white: 'A' },
+      { black: 'D', result: 'white', white: 'B' },
+    ],
+  },
+  {
+    byes: [],
+    games: [
+      { black: 'D', result: 'draw', white: 'A' },
+      { black: 'C', result: 'white', white: 'B' },
+    ],
+  },
+];
+
+describe('koya limit variants', () => {
+  it('base KS keeps threshold 50%', () => {
+    expect(koya('A', ROUNDS, PLAYERS)).toBe(1);
+  });
+
+  it('KS/L-1 lowers the limit by half a point', () => {
+    expect(koyaLimitM1('A', ROUNDS, PLAYERS)).toBe(2);
+  });
+
+  it('KS/L-2 lowers the limit by one point', () => {
+    expect(koyaLimitM2('A', ROUNDS, PLAYERS)).toBe(2.5);
+  });
+
+  it('includes an opponent scoring exactly the lowered limit', () => {
+    expect(koyaLimitM1('B', ROUNDS, PLAYERS)).toBe(1);
+  });
+});

--- a/src/limit-m1.ts
+++ b/src/limit-m1.ts
@@ -2,10 +2,10 @@ import { koyaScore } from './utilities.js';
 
 import type { Tiebreak } from '@echecs/tournament';
 
-const koya: Tiebreak = (player, rounds, players) =>
-  koyaScore(player, rounds, players, rounds.length / 2);
+const koyaLimitM1: Tiebreak = (player, rounds, players) =>
+  koyaScore(player, rounds, players, rounds.length / 2 - 0.5);
 
-export { koya, koya as tiebreak };
+export { koyaLimitM1, koyaLimitM1 as tiebreak };
 
 export type {
   Bye,

--- a/src/limit-m2.ts
+++ b/src/limit-m2.ts
@@ -2,10 +2,10 @@ import { koyaScore } from './utilities.js';
 
 import type { Tiebreak } from '@echecs/tournament';
 
-const koya: Tiebreak = (player, rounds, players) =>
-  koyaScore(player, rounds, players, rounds.length / 2);
+const koyaLimitM2: Tiebreak = (player, rounds, players) =>
+  koyaScore(player, rounds, players, rounds.length / 2 - 1);
 
-export { koya, koya as tiebreak };
+export { koyaLimitM2, koyaLimitM2 as tiebreak };
 
 export type {
   Bye,

--- a/src/limit-p1.ts
+++ b/src/limit-p1.ts
@@ -1,0 +1,16 @@
+import { koyaScore } from './utilities.js';
+
+import type { Tiebreak } from '@echecs/tournament';
+
+const koyaLimitP1: Tiebreak = (player, rounds, players) =>
+  koyaScore(player, rounds, players, rounds.length / 2 + 0.5);
+
+export { koyaLimitP1, koyaLimitP1 as tiebreak };
+
+export type {
+  Bye,
+  CompletedRound,
+  Game,
+  Pairing,
+  Player,
+} from '@echecs/tournament';

--- a/src/limit-p2.ts
+++ b/src/limit-p2.ts
@@ -1,0 +1,16 @@
+import { koyaScore } from './utilities.js';
+
+import type { Tiebreak } from '@echecs/tournament';
+
+const koyaLimitP2: Tiebreak = (player, rounds, players) =>
+  koyaScore(player, rounds, players, rounds.length / 2 + 1);
+
+export { koyaLimitP2, koyaLimitP2 as tiebreak };
+
+export type {
+  Bye,
+  CompletedRound,
+  Game,
+  Pairing,
+  Player,
+} from '@echecs/tournament';

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,4 @@
-import type { CompletedRound, Game } from '@echecs/tournament';
+import type { CompletedRound, Game, Player } from '@echecs/tournament';
 
 function gamesForPlayer(player: string, rounds: CompletedRound[]): Game[] {
   return rounds
@@ -25,4 +25,26 @@ function scoreFor(player: string, game: Game): number {
     : 0;
 }
 
-export { gamesForPlayer, opponents, scoreFor };
+function koyaScore(
+  player: string,
+  rounds: CompletedRound[],
+  players: Player[],
+  threshold: number,
+): number {
+  let sum = 0;
+  for (const opp of opponents(player, rounds)) {
+    const opponent = players.find((p) => p.id === opp);
+    if (opponent === undefined || opponent.points < threshold) {
+      continue;
+    }
+    const gamesBetween = gamesForPlayer(player, rounds).filter(
+      (g) => g.white === opp || g.black === opp,
+    );
+    for (const g of gamesBetween) {
+      sum += scoreFor(player, g);
+    }
+  }
+  return sum;
+}
+
+export { gamesForPlayer, koyaScore, opponents, scoreFor };

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   dts: true,
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/limit-m1.ts', 'src/limit-m2.ts'],
   format: 'esm',
   minify: true,
   outDir: 'dist',

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,13 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   dts: true,
-  entry: ['src/index.ts', 'src/limit-m1.ts', 'src/limit-m2.ts'],
+  entry: [
+    'src/index.ts',
+    'src/limit-m1.ts',
+    'src/limit-m2.ts',
+    'src/limit-p1.ts',
+    'src/limit-p2.ts',
+  ],
   format: 'esm',
   minify: true,
   outDir: 'dist',


### PR DESCRIPTION
## Summary
- Add four Koya limit variants per FIDE C.07 9.2 + 14.5:
  - `@echecs/koya/limit-m1` — limit 50% − ½ (`koyaLimitM1`)
  - `@echecs/koya/limit-m2` — limit 50% − 1 (`koyaLimitM2`)
  - `@echecs/koya/limit-p1` — limit 50% + ½ (`koyaLimitP1`)
  - `@echecs/koya/limit-p2` — limit 50% + 1 (`koyaLimitP2`)
- Each subpath exports its named function plus a `tiebreak` alias and shared types.
- Document the new subpaths in the README and add the 4.1.0 CHANGELOG entry.