### PR TITLE
release: @echecs/koya@4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "4.0.0"
+  "version": "4.1.0"
 }


### PR DESCRIPTION
Version bump to 4.1.0 for the Koya limit variants (KS/L±1, KS/L±2) added in #129. Triggers npm publish via the release workflow on merge.