### PR TITLE
release: @echecs/koya@4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.1] - 2026-08-30
+
+### Fixed
+
+- README limit variants include opponents scoring exactly the limit (FIDE C.07
+  9.2 "at least") and corrected type export documentation.
+
 ## [4.1.0] - 2026-08-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "4.1.0"
+  "version": "4.1.1"
 }


### PR DESCRIPTION
Release 4.1.1 — README docs corrections shipped in the tarball (limit-variant 'at least' semantics, actual type exports).